### PR TITLE
🐛(example): Fix "Type NavigateService is already registered" error (fix #1 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@ FlutterPageRouter routerInit () {
   return router;
 }
 
+FlutterPageRouter router = routerInit(); // Initialization Router
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-
-    FlutterPageRouter router = routerInit(); // Initialization Router
-
     return MaterialApp(
       title: 'Flutter',
       theme: ThemeData(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,11 +5,11 @@ import './router/index.dart';
 
 void main() => runApp(MyApp());
 
+FlutterPageRouter router = routerInit();
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-
-    FlutterPageRouter router = routerInit();
 
     return MaterialApp(
       title: 'Flutter',


### PR DESCRIPTION
It seems that latest get_it version broke the example app, so I moved the router init and the error is now gone.